### PR TITLE
Fix the license check.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Check licenses
       run: |
-        go get -u github.com/google/addlicense
+        go install github.com/google/addlicense@v1.1.1
         export PATH=$PATH:$(go env GOPATH)/bin
         addlicense -check .
 


### PR DESCRIPTION
This is from [this bigger PR](https://github.com/proxy-wasm/test-framework/pull/12)

This _should_:
- [x] fix the license checker step in gh actions 77abffeb4cb0078fa87bee41daaaf506d42d9d0b
- ~fix testing the examples from the `proxy-wasm-rust-sdk` by using `v0.1.4` explicitly b3b1164c95023bbeac158f105943eb22769bd9c8~

Next would be upgrading to the [latest wasmtime](https://github.com/proxy-wasm/test-framework/commit/efdfd31aab30bf4aaca000c044d07b8f4b66f4b5), so that the `cargo outdated` step of CI stops failing. 