### PR TITLE
Assert gRPC calls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -139,7 +139,7 @@ jobs:
       with:
         repository: proxy-wasm/proxy-wasm-rust-sdk
         path: proxy-wasm-rust-sdk
-        ref: v0.2.1
+        ref: v0.2.2
 
     - name: Update Rust
       run: |
@@ -179,6 +179,7 @@ jobs:
         cd proxy-wasm-rust-sdk/examples/hello_world && cargo build --target wasm32-unknown-unknown --release && cd ../../..
         cd proxy-wasm-rust-sdk/examples/http_auth_random && cargo build --target wasm32-unknown-unknown --release && cd ../../..
         cd proxy-wasm-rust-sdk/examples/http_headers && cargo build --target wasm32-unknown-unknown --release && cd ../../..
+        cd proxy-wasm-rust-sdk/examples/grpc_auth_random && cargo build --target wasm32-unknown-unknown --release && cd ../../..
 
     - name: Test (hello_world)
       run: target/release/examples/hello_world proxy-wasm-rust-sdk/examples/hello_world/target/wasm32-unknown-unknown/release/proxy_wasm_example_hello_world.wasm
@@ -188,6 +189,9 @@ jobs:
 
     - name: Test (http_headers)
       run: target/release/examples/http_headers proxy-wasm-rust-sdk/examples/http_headers/target/wasm32-unknown-unknown/release/proxy_wasm_example_http_headers.wasm -a
+
+    - name: Test (grpc_auth_random)
+      run: target/release/examples/grpc_auth_random proxy-wasm-rust-sdk/examples/grpc_auth_random/target/wasm32-unknown-unknown/release/proxy_wasm_example_grpc_auth_random.wasm
 
   outdated:
     runs-on: ubuntu-latest

--- a/examples/grpc_auth_random.rs
+++ b/examples/grpc_auth_random.rs
@@ -1,0 +1,69 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use proxy_wasm_test_framework::tester;
+use proxy_wasm_test_framework::types::*;
+use structopt::StructOpt;
+
+fn main() -> Result<()> {
+    let args = tester::MockSettings::from_args();
+    let mut module = tester::mock(args)?;
+
+    module.call_start().execute_and_expect(ReturnType::None)?;
+
+    let root_context = 1;
+    module
+        .call_proxy_on_context_create(root_context, 0)
+        .execute_and_expect(ReturnType::None)?;
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .execute_and_expect(ReturnType::None)?;
+
+    let token_id = 42;
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("content-type"))
+        .returning(Some("application/grpc"))
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":path"))
+        .returning(Some("/someService/someService.someMethod"))
+        .expect_grpc_call(
+            Some("grpcbin"),
+            Some("grpcbin.GRPCBin"),
+            Some("RandomError"),
+            Some(&[0, 0, 0, 0]),
+            Some(&[]),
+            Some(1000), // 1 sec as millis
+        )
+        .returning(Some(token_id))
+        .execute_and_expect(ReturnType::Action(Action::Pause))?;
+
+    module
+        .call_proxy_on_grpc_receive(http_context, token_id as i32, 0 as i32)
+        .expect_log(Some(LogLevel::Info), Some("Access granted."))
+        .execute_and_expect(ReturnType::None)?;
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_replace_header_map_value(
+            Some(MapType::HttpResponseHeaders),
+            Some("Powered-By"),
+            Some("proxy-wasm"),
+        )
+        .execute_and_expect(ReturnType::Action(Action::Continue))?;
+
+    return Ok(());
+}

--- a/examples/http_auth_random.rs
+++ b/examples/http_auth_random.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
     http_auth_random
         .call_proxy_on_http_call_response(http_context, 0, 0, buffer_data.len() as i32, 0)
         .expect_get_buffer_bytes(Some(BufferType::HttpCallResponseBody))
-        .returning(Some(buffer_data))
+        .returning(Some(buffer_data.as_bytes()))
         .expect_send_local_response(
             Some(403),
             Some("Access forbidden.\n"),

--- a/src/expect_interface.rs
+++ b/src/expect_interface.rs
@@ -51,7 +51,7 @@ impl<'a> ExpectGetBufferBytes<'a> {
         }
     }
 
-    pub fn returning(&mut self, buffer_data: Option<&str>) -> &mut Tester {
+    pub fn returning(&mut self, buffer_data: Option<&[u8]>) -> &mut Tester {
         self.tester
             .get_expect_handle()
             .staged
@@ -144,6 +144,51 @@ impl<'a> ExpectHttpCall<'a> {
             self.headers.take().unwrap(),
             self.body,
             self.trailers.take().unwrap(),
+            self.timeout,
+            token_id,
+        );
+        self.tester
+    }
+}
+
+pub struct ExpectGrpcCall<'a> {
+    tester: &'a mut Tester,
+    service: Option<&'a str>,
+    service_name: Option<&'a str>,
+    method_name: Option<&'a str>,
+    initial_metadata: Option<&'a [u8]>,
+    request: Option<&'a [u8]>,
+    timeout: Option<u64>,
+}
+
+impl<'a> ExpectGrpcCall<'a> {
+    pub fn expecting(
+        tester: &'a mut Tester,
+        service: Option<&'a str>,
+        service_name: Option<&'a str>,
+        method_name: Option<&'a str>,
+        initial_metadata: Option<&'a [u8]>,
+        request: Option<&'a [u8]>,
+        timeout: Option<u64>,
+    ) -> Self {
+        Self {
+            tester,
+            service,
+            service_name,
+            method_name,
+            initial_metadata,
+            request,
+            timeout,
+        }
+    }
+
+    pub fn returning(&mut self, token_id: Option<u32>) -> &mut Tester {
+        self.tester.get_expect_handle().staged.set_expect_grpc_call(
+            self.service,
+            self.service_name,
+            self.method_name,
+            self.initial_metadata,
+            self.request,
             self.timeout,
             token_id,
         );

--- a/src/host_settings.rs
+++ b/src/host_settings.rs
@@ -294,5 +294,9 @@ pub fn default_buffer_bytes() -> HashMap<i32, Bytes> {
         BufferType::HttpCallResponseBody as i32,
         "default_call_response_body".as_bytes().to_vec(),
     );
+    default_bytes.insert(
+        BufferType::GrpcReceiveBuffer as i32,
+        "default_grpc_receive_buffer".as_bytes().to_vec(),
+    );
     default_bytes
 }

--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -1404,7 +1404,7 @@ fn get_hostfunc(
                  timeout_milliseconds: i32,
                  token_ptr: i32|
                  -> i32 {
-                    print!("[vm->host] proxy_grpc_call({initial_metadata_ptr}, {initial_metadata_size})");
+                    println!("[vm->host] proxy_grpc_call({initial_metadata_ptr}, {initial_metadata_size})");
 
                     // Default Function: receives and displays http call from proxy-wasm module
                     // Expectation: asserts equal the receieved http call with the expected one

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -268,6 +268,26 @@ impl Tester {
         ExpectHttpCall::expecting(self, upstream, headers, body, trailers, timeout)
     }
 
+    pub fn expect_grpc_call(
+        &mut self,
+        service: Option<&'static str>,
+        service_name: Option<&'static str>,
+        method_name: Option<&'static str>,
+        initial_metadata: Option<&'static [u8]>,
+        request: Option<&'static [u8]>,
+        timeout: Option<u64>,
+    ) -> ExpectGrpcCall {
+        ExpectGrpcCall::expecting(
+            self,
+            service,
+            service_name,
+            method_name,
+            initial_metadata,
+            request,
+            timeout,
+        )
+    }
+
     /* ------------------------------------- High-level Expectation Setting ------------------------------------- */
 
     pub fn set_quiet(&mut self, quiet: bool) {
@@ -323,7 +343,10 @@ impl Tester {
     }
 
     fn assert_expect_stage(&mut self) {
-        self.expect.lock().unwrap().assert_stage();
+        let err = self.expect.lock().unwrap().assert_stage();
+        if let Some(msg) = err {
+            panic!("{}", msg)
+        }
     }
 
     pub fn get_settings_handle(&self) -> MutexGuard<HostHandle> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,9 @@ pub enum BufferType {
     DownstreamData = 2,
     UpstreamData = 3,
     HttpCallResponseBody = 4,
+    GrpcReceiveBuffer = 5,
+    VmConfiguration = 6,
+    PluginConfiguration = 7,
 }
 
 #[repr(u32)]


### PR DESCRIPTION
This is one of the two additions we've done to the framework: support asserting on gRPC calls
Follow up would be reading properties: https://github.com/Kuadrant/wasm-test-framework/pull/1 