### PR TITLE
Add additional buffer types

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,9 @@ pub enum BufferType {
     DownstreamData = 2,
     UpstreamData = 3,
     HttpCallResponseBody = 4,
+    GrpcReceiveBuffer = 5,
+    VmConfiguration = 6,
+    PluginConfiguration = 7,
 }
 
 #[repr(u32)]


### PR DESCRIPTION
This change adds support for 3 additional buffer types which are present in `proxy-wasm-rust-sdk`