### PR TITLE
Add additional buffer types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmtime = "11.0.1"
+wasmtime = "22.0.0"
 anyhow = "1.0.72"
 lazy_static = "1.4.0"
 more-asserts = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmtime = "22.0.0"
+wasmtime = "11.0.1"
 anyhow = "1.0.72"
 lazy_static = "1.4.0"
 more-asserts = "0.3.1"

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,9 @@ pub enum BufferType {
     DownstreamData = 2,
     UpstreamData = 3,
     HttpCallResponseBody = 4,
+    GrpcReceiveBuffer = 5,
+    VmConfiguration = 6,
+    PluginConfiguration = 7,
 }
 
 #[repr(u32)]


### PR DESCRIPTION
This change adds support for 3 additional buffer types which are present in proxy-wasm-rust-sdk