### PR TITLE
Only enable minimum set of wasmtime features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasmtime = "23.0.1"
+wasmtime = { version = "24.0.0", default-features = false, features = ["cranelift", "parallel-compilation", "std", "runtime"] }
 anyhow = "1.0.72"
 lazy_static = "1.4.0"
 more-asserts = "0.3.1"

--- a/src/expect_interface.rs
+++ b/src/expect_interface.rs
@@ -25,7 +25,7 @@ pub struct ExpectGetCurrentTimeNanos<'a> {
 }
 
 impl<'a> ExpectGetCurrentTimeNanos<'a> {
-    pub fn expecting(tester: &'a mut Tester) -> ExpectGetCurrentTimeNanos {
+    pub fn expecting(tester: &'a mut Tester) -> ExpectGetCurrentTimeNanos<'a> {
         ExpectGetCurrentTimeNanos { tester: tester }
     }
 
@@ -44,7 +44,7 @@ pub struct ExpectGetBufferBytes<'a> {
 }
 
 impl<'a> ExpectGetBufferBytes<'a> {
-    pub fn expecting(tester: &'a mut Tester, buffer_type: Option<i32>) -> ExpectGetBufferBytes {
+    pub fn expecting(tester: &'a mut Tester, buffer_type: Option<i32>) -> ExpectGetBufferBytes<'a> {
         ExpectGetBufferBytes {
             tester: tester,
             buffer_type: buffer_type,
@@ -66,7 +66,7 @@ pub struct ExpectGetHeaderMapPairs<'a> {
 }
 
 impl<'a> ExpectGetHeaderMapPairs<'a> {
-    pub fn expecting(tester: &'a mut Tester, map_type: Option<i32>) -> ExpectGetHeaderMapPairs {
+    pub fn expecting(tester: &'a mut Tester, map_type: Option<i32>) -> ExpectGetHeaderMapPairs<'a> {
         ExpectGetHeaderMapPairs {
             tester: tester,
             map_type: map_type,

--- a/src/settings_interface.rs
+++ b/src/settings_interface.rs
@@ -20,7 +20,7 @@ pub struct DefaultBufferBytes<'a> {
 }
 
 impl<'a> DefaultBufferBytes<'a> {
-    pub fn expecting(tester: &'a mut Tester, buffer_type: i32) -> DefaultBufferBytes {
+    pub fn expecting(tester: &'a mut Tester, buffer_type: i32) -> DefaultBufferBytes<'a> {
         DefaultBufferBytes {
             tester: tester,
             buffer_type: buffer_type,
@@ -42,7 +42,7 @@ pub struct DefaultHeaderMapPairs<'a> {
 }
 
 impl<'a> DefaultHeaderMapPairs<'a> {
-    pub fn expecting(tester: &'a mut Tester, map_type: i32) -> DefaultHeaderMapPairs {
+    pub fn expecting(tester: &'a mut Tester, map_type: i32) -> DefaultHeaderMapPairs<'a> {
         DefaultHeaderMapPairs {
             tester: tester,
             map_type: map_type,


### PR DESCRIPTION
Updated wasmtime to the latest release and removed some of the otherwise default features that are actually not needed afaict

Some introduce the need for "newer" toolchains (e.g. `wat`) that might be an issue for some test environments out there, despite the dependency actually not being required. 